### PR TITLE
fix: airdrop withdraw_all permission

### DIFF
--- a/contracts/cw20-merkle-airdrop/src/contract.rs
+++ b/contracts/cw20-merkle-airdrop/src/contract.rs
@@ -197,12 +197,6 @@ pub fn execute_withdraw_all(
     env: Env,
     info: MessageInfo,
 ) -> Result<Response, ContractError> {
-    // authorize owner
-    let cfg = CONFIG.load(deps.storage)?;
-    if info.sender != cfg.owner {
-        return Err(ContractError::Unauthorized {});
-    }
-
     let vesting_start = VESTING_START.load(deps.storage)?;
     let vesting_duration = VESTING_DURATION.load(deps.storage)?;
     let expiration = vesting_start + vesting_duration;
@@ -224,6 +218,7 @@ pub fn execute_withdraw_all(
 
     // Get the current total balance for the contract and burn it all.
     // By burning, we exchange them for NTRN tokens
+    let cfg = CONFIG.load(deps.storage)?;
     let amount_to_withdraw = deps
         .querier
         .query_wasm_smart::<BalanceResponse>(


### PR DESCRIPTION
Should be permissionless, but was done permissioned by the owner (the main DAO) by a mistake.
```rust
pub enum ExecuteMsg {
    ...
    /// Permissionless, activated after vesting is over (consult to `[InstantiateMsg]`
    /// documentation for more info). Withdraws all remaining cNTRN tokens, burns them,
    /// receiving NTRN in exchange, and sends all received NTRN's to reserve.
    WithdrawAll {},
    ...
}
```

**tests run:** https://github.com/neutron-org/neutron-tests/actions/runs/4700640888