### PR TITLE
chore: bump neutron-sdk to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1047,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "neutron-sdk"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a57cb451a16a676ecbbb1bb1e0e2e9bc9989834d82c6b16eebc24d9ed97cf"
+checksum = "487305afc06808aabe5b90684bc238c93fb8872a275edf6db4ea24b102eb9a8e"
 dependencies = [
  "base64 0.20.0",
  "bech32",

--- a/contracts/price-feed/Cargo.toml
+++ b/contracts/price-feed/Cargo.toml
@@ -47,7 +47,7 @@ cosmwasm-storage = "1.1.3"
 cw-storage-plus = "1.0.1"
 cw2 = "1.0.1"
 cw-band = "0.1.1"
-neutron-sdk = { default-features = false, version = "0.4.0" }
+neutron-sdk = "0.5.0"
 base64 = "0.21.0"
 protobuf = { version = "3.2.0", features = ["with-bytes"] }
 prost = "0.11"


### PR DESCRIPTION
This PR:
- upgrades all contracts to neutron-sdk v0.5.0

Merge with:
- https://github.com/neutron-org/neutron-dev-contracts/pull/16
- https://github.com/neutron-org/neutron-dao/pull/59
- https://github.com/neutron-org/neutron-integration-tests/pull/147

[[Recent test run](https://github.com/neutron-org/neutron-tests/actions/runs/4868744229)]