### PR TITLE
added update_reserve method. withdraw_all is permissioned #NTRN-95

### DIFF
--- a/contracts/cw20-merkle-airdrop/schema/cw20-merkle-airdrop.json
+++ b/contracts/cw20-merkle-airdrop/schema/cw20-merkle-airdrop.json
@@ -137,6 +137,26 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "update_reserve"
+        ],
+        "properties": {
+          "update_reserve": {
+            "type": "object",
+            "required": [
+              "address"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {

--- a/contracts/cw20-merkle-airdrop/schema/raw/execute.json
+++ b/contracts/cw20-merkle-airdrop/schema/raw/execute.json
@@ -67,6 +67,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_reserve"
+      ],
+      "properties": {
+        "update_reserve": {
+          "type": "object",
+          "required": [
+            "address"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/contracts/cw20-merkle-airdrop/src/msg.rs
+++ b/contracts/cw20-merkle-airdrop/src/msg.rs
@@ -42,6 +42,9 @@ pub enum ExecuteMsg {
     WithdrawAll {},
     Pause {},
     Resume {},
+    UpdateReserve {
+        address: String,
+    },
 }
 
 #[cw_serde]


### PR DESCRIPTION
The aims of the pr are:
1) make `withdraw_all` permissioned
2) implement method `update_reserve` to update reserve address

https://github.com/neutron-org/neutron-integration-tests/pull/192/files

https://github.com/neutron-org/neutron-tests/actions/runs/5890762631