### PR TITLE
chore: make PCL migration status optional for lockdrop and vesting lp base

### DIFF
--- a/contracts/lockdrop/src/contract.rs
+++ b/contracts/lockdrop/src/contract.rs
@@ -154,8 +154,8 @@ pub fn instantiate(
 /// * **ExecuteMsg::ClaimOwnership {}** Claims contract ownership.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
-    let migration_state: MigrationState = MIGRATION_STATUS.load(deps.storage)?;
-    if migration_state != MigrationState::Completed {
+    let migration_state = MIGRATION_STATUS.may_load(deps.storage)?;
+    if migration_state.unwrap_or(MigrationState::Completed) != MigrationState::Completed {
         match msg {
             ExecuteMsg::MigrateFromXykToCl(..) => {}
             ExecuteMsg::Callback(..) => {}
@@ -400,8 +400,8 @@ fn _handle_callback(
 ///     }** Returns a total amount of LP tokens for the specified pool at a specific height.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
-    let migration_state: MigrationState = MIGRATION_STATUS.load(deps.storage)?;
-    if migration_state != MigrationState::Completed {
+    let migration_state = MIGRATION_STATUS.may_load(deps.storage)?;
+    if migration_state.unwrap_or(MigrationState::Completed) != MigrationState::Completed {
         match msg {
             QueryMsg::QueryUserLockupTotalAtHeight { .. }
             | QueryMsg::QueryLockupTotalAtHeight { .. } => {

--- a/packages/vesting-base-lp/src/handlers.rs
+++ b/packages/vesting-base-lp/src/handlers.rs
@@ -33,8 +33,8 @@ pub fn execute(
     info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
-    let migration_state: MigrationState = MIGRATION_STATUS.load(deps.storage)?;
-    if migration_state != MigrationState::Completed {
+    let migration_state = MIGRATION_STATUS.may_load(deps.storage)?;
+    if migration_state.unwrap_or(MigrationState::Completed) != MigrationState::Completed {
         match msg {
             ExecuteMsg::MigrateLiquidity {
                 slippage_tolerance: _,
@@ -610,8 +610,8 @@ fn post_migration_vesting_reschedule_callback(
 
 /// Exposes all the queries available in the contract.
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
-    let migration_state: MigrationState = MIGRATION_STATUS.load(deps.storage)?;
-    if migration_state != MigrationState::Completed {
+    let migration_state = MIGRATION_STATUS.may_load(deps.storage)?;
+    if migration_state.unwrap_or(MigrationState::Completed) != MigrationState::Completed {
         return Err(ContractError::MigrationIncomplete {}.into());
     }
 


### PR DESCRIPTION
**summary:**

Migration implementations for lockdrop and vesting lp vault contracts made the contracts unusable without migration call because execute and query entry points expect `MIGRATION_STATUS` to be defined whereas it's not unless contract's migration called. This PR fixes it making the `MIGRATION_STATUS` optional.