### PR TITLE
[NTRN-127] chore: small improvements

### DIFF
--- a/contracts/astroport/oracle/src/contract.rs
+++ b/contracts/astroport/oracle/src/contract.rs
@@ -42,10 +42,16 @@ pub fn instantiate(
     Ok(Response::default())
 }
 
+/// ## Description
 /// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
 ///
-/// ## Variants
-/// * **ExecuteMsg::Update {}** Updates the local TWAP values for the assets in the Astroport pool.
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -174,10 +180,12 @@ pub fn update(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
 }
 
 /// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
 ///
-/// ## Queries
-/// * **QueryMsg::Consult { token, amount }** Validates assets and calculates a new average
-/// amount with updated precision
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> Result<Binary, ContractError> {
     match msg {

--- a/contracts/auction/src/contract.rs
+++ b/contracts/auction/src/contract.rs
@@ -113,11 +113,6 @@ pub fn instantiate(
 /// * **info** is an object of type [`MessageInfo`].
 ///
 /// * **msg** is an object of type [`ExecuteMsg`].
-///
-/// ## Execute messages
-///
-/// * **ExecuteMsg::Receive(msg)** Parse incoming messages from the NTRN token.
-///
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -229,13 +224,6 @@ pub fn execute_deposit(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Res
 /// * **_env** is an object of type [`Env`].
 ///
 /// * **msg** is an object of type [`QueryMsg`].
-///
-/// ## Queries
-/// * **QueryMsg::Config {}** Returns the config info.
-///
-/// * **QueryMsg::State {}** Returns state of the contract.
-///
-/// * **QueryMsg::UserInfo { address }** Returns user position details.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {

--- a/contracts/credits/src/contract.rs
+++ b/contracts/credits/src/contract.rs
@@ -74,6 +74,16 @@ pub fn instantiate(
     Ok(Response::new())
 }
 
+/// ## Description
+/// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
+///
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -388,6 +398,13 @@ pub fn execute_mint(deps: DepsMut, env: Env, info: MessageInfo) -> Result<Respon
         .map_err(Cw20Error)
 }
 
+/// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
+///
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {

--- a/contracts/cw20-merkle-airdrop/src/contract.rs
+++ b/contracts/cw20-merkle-airdrop/src/contract.rs
@@ -80,6 +80,16 @@ pub fn instantiate(
     ]))
 }
 
+/// ## Description
+/// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
+///
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -332,6 +342,13 @@ pub fn execute_resume(
     Ok(Response::new().add_attributes(vec![attr("action", "resume"), attr("paused", "false")]))
 }
 
+/// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
+///
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {

--- a/contracts/lockdrop/src/contract.rs
+++ b/contracts/lockdrop/src/contract.rs
@@ -129,29 +129,6 @@ pub fn instantiate(
 /// * **info** is an object of type [`MessageInfo`].
 ///
 /// * **msg** is an object of type [`ExecuteMsg`].
-///
-/// ## Execute messages
-///
-/// * **ExecuteMsg::Receive(msg)** Parse incoming messages from the cNTRN token.
-///
-/// * **ExecuteMsg::UpdateConfig { new_config }** Admin function to update configuration parameters.
-///
-/// * **ExecuteMsg::InitializePool {
-///     pool_type,
-///     incentives_share,
-/// }** Facilitates addition of new Pool (axlrUSDC/NTRN or ATOM/NTRN) whose LP tokens can then be locked in the lockdrop contract.
-///
-/// * **ExecuteMsg::ClaimRewardsAndOptionallyUnlock {
-///             terraswap_lp_token,
-///             duration,
-///             withdraw_lp_stake,
-///         }** Claims user Rewards for a particular Lockup position.
-///
-/// * **ExecuteMsg::ProposeNewOwner { owner, expires_in }** Creates a request to change contract ownership.
-///
-/// * **ExecuteMsg::DropOwnershipProposal {}** Removes a request to change contract ownership.
-///
-/// * **ExecuteMsg::ClaimOwnership {}** Claims contract ownership.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
     let migration_state = MIGRATION_STATUS.may_load(deps.storage)?;
@@ -376,40 +353,6 @@ struct MigratePairStep2Data {
 /// * **_env** is an object of type [`Env`].
 ///
 /// * **msg** is an object of type [`QueryMsg`].
-///
-/// ## Queries
-/// * **QueryMsg::Config {}** Returns the config info.
-///
-/// * **QueryMsg::State {}** Returns the contract's state info.
-///
-/// * **QueryMsg::Pool { terraswap_lp_token }** Returns info regarding a certain supported LP token pool.
-///
-/// * **QueryMsg::UserInfo { address }** Returns info regarding a user (total NTRN rewards, list of lockup positions).
-///
-/// * **QueryMsg::UserInfoWithLockupsList { address }** Returns info regarding a user with lockups.
-///
-/// * **QueryMsg::LockUpInfo {
-///             user_address,
-///             terraswap_lp_token,
-///             duration,
-///         }** Returns info regarding a particular lockup position with a given duration and identifer for the LP tokens locked.
-///
-/// * **QueryMsg::PendingAssetReward {
-///             user_address,
-///             terraswap_lp_token,
-///             duration,
-///         }** Returns the amount of pending asset rewards for the specified recipient and for a specific lockup position.
-///
-/// * **QueryUserLockupTotalAtHeight {
-///         pool_type: PoolType,
-///         user_address: String,
-///         height: u64,
-///     }** Returns locked amount of LP tokens for the specified user for the specified pool at a specific height.
-///
-/// * **QueryLockupTotalAtHeight {
-///         pool_type: PoolType,
-///         height: u64,
-///     }** Returns a total amount of LP tokens for the specified pool at a specific height.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     let migration_state = MIGRATION_STATUS.may_load(deps.storage)?;

--- a/contracts/lockdrop/src/contract.rs
+++ b/contracts/lockdrop/src/contract.rs
@@ -493,6 +493,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> StdResult<Response>
 
     MIGRATION_STATUS.save(deps.storage, &MigrationState::MigrateLiquidity)?;
 
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     Ok(Response::default().add_attributes(attrs))
 }
 

--- a/contracts/lockdrop/src/contract.rs
+++ b/contracts/lockdrop/src/contract.rs
@@ -882,7 +882,7 @@ fn migrate_users(
         attrs.push(attr("users_count", users.len().to_string()));
         for user in users {
             for pool_type in &pool_types {
-                let mut total_lokups = Uint128::zero();
+                let mut total_lockups = Uint128::zero();
                 let lookup_infos: Vec<(u64, LockupInfoV2)> = LOCKUP_INFO
                     .prefix((*pool_type, &user))
                     .range(deps.storage, None, None, Order::Ascending)
@@ -896,14 +896,14 @@ fn migrate_users(
                     lockup_info.lp_units_locked =
                         (*kf).checked_mul_uint128(lockup_info.lp_units_locked)?;
                     LOCKUP_INFO.save(deps.storage, (*pool_type, &user, duration), &lockup_info)?;
-                    total_lokups += lockup_info.lp_units_locked;
+                    total_lockups += lockup_info.lp_units_locked;
                 }
                 // update user's total lockup amount
                 TOTAL_USER_LOCKUP_AMOUNT.update(
                     deps.storage,
                     (*pool_type, &user),
                     env.block.height,
-                    |_lockup_amount| -> StdResult<Uint128> { Ok(total_lokups) },
+                    |_lockup_amount| -> StdResult<Uint128> { Ok(total_lockups) },
                 )?;
             }
         }

--- a/contracts/price-feed/src/contract.rs
+++ b/contracts/price-feed/src/contract.rs
@@ -60,6 +60,16 @@ pub fn instantiate(
     Ok(Response::new().add_attribute("method", "instantiate"))
 }
 
+/// ## Description
+/// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
+///
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -177,6 +187,13 @@ pub fn migrate(_deps: DepsMut, _env: Env, _msg: Empty) -> StdResult<Response> {
     Ok(Response::default())
 }
 
+/// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
+///
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {

--- a/contracts/vesting-investors/src/contract.rs
+++ b/contracts/vesting-investors/src/contract.rs
@@ -31,7 +31,16 @@ pub fn instantiate(
     Ok(Response::default())
 }
 
-/// Exposes execute functions available in the contract.
+/// ## Description
+/// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
+///
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -43,6 +52,12 @@ pub fn execute(
 }
 
 /// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
+///
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     base_query(deps, env, msg)

--- a/contracts/vesting-investors/src/contract.rs
+++ b/contracts/vesting-investors/src/contract.rs
@@ -51,5 +51,6 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 /// Exposes migrate function.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     base_migrate(deps, env, msg)
 }

--- a/contracts/vesting-lp/src/contract.rs
+++ b/contracts/vesting-lp/src/contract.rs
@@ -31,7 +31,16 @@ pub fn instantiate(
     Ok(Response::default())
 }
 
-/// Exposes execute functions available in the contract.
+/// ## Description
+/// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
+///
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -43,6 +52,12 @@ pub fn execute(
 }
 
 /// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
+///
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     base_query(deps, env, msg)

--- a/contracts/vesting-lp/src/contract.rs
+++ b/contracts/vesting-lp/src/contract.rs
@@ -51,5 +51,6 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
 /// Exposes migrate functions available in the contract.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
     base_migrate(deps, env, msg)
 }

--- a/contracts/vesting-lti/src/contract.rs
+++ b/contracts/vesting-lti/src/contract.rs
@@ -38,7 +38,16 @@ pub fn instantiate(
     Ok(Response::default())
 }
 
-/// Exposes execute functions available in the contract.
+/// ## Description
+/// Exposes all the execute functions available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`DepsMut`].
+///
+/// * **env** is an object of type [`Env`].
+///
+/// * **info** is an object of type [`MessageInfo`].
+///
+/// * **msg** is an object of type [`ExecuteMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
     deps: DepsMut,
@@ -50,6 +59,12 @@ pub fn execute(
 }
 
 /// Exposes all the queries available in the contract.
+/// ## Params
+/// * **deps** is an object of type [`Deps`].
+///
+/// * **_env** is an object of type [`Env`].
+///
+/// * **msg** is an object of type [`QueryMsg`].
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
     base_query(deps, env, msg)

--- a/packages/astroport_periphery/src/lockdrop.rs
+++ b/packages/astroport_periphery/src/lockdrop.rs
@@ -313,12 +313,9 @@ pub struct State {
     pub total_incentives_share: Uint128,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub enum MigrationState {
-    #[default]
-    /// Migration is started
-    Started,
-    ///
+    /// Migration is started, the first step is liquidity migration
     MigrateLiquidity,
     /// Liquidity is migrated, can migrate users with pagination
     MigrateUsers,

--- a/packages/vesting-base-lp/src/ext_managed.rs
+++ b/packages/vesting-base-lp/src/ext_managed.rs
@@ -3,9 +3,7 @@ use crate::handlers::get_vesting_token;
 use crate::msg::{ExecuteMsgManaged, QueryMsgManaged};
 use crate::state::{vesting_info, vesting_state, CONFIG};
 use astroport::asset::AssetInfoExt;
-use cosmwasm_std::{
-    attr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, SubMsg, Uint128,
-};
+use cosmwasm_std::{attr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128};
 
 /// Contains the managed extension check and routing of the message.
 pub(crate) fn handle_execute_managed_msg(
@@ -86,7 +84,7 @@ fn remove_vesting_accounts(
             let transfer_msg = vesting_token
                 .with_balance(amount_to_claw_back)
                 .into_msg(clawback_address.clone())?;
-            response = response.add_submessage(SubMsg::new(transfer_msg));
+            response = response.add_message(transfer_msg);
 
             vesting_state(config.extensions.historical).update::<_, ContractError>(
                 deps.storage,

--- a/packages/vesting-base-lp/src/handlers.rs
+++ b/packages/vesting-base-lp/src/handlers.rs
@@ -21,7 +21,7 @@ use astroport::pair::{
 };
 use cosmwasm_std::{
     attr, from_binary, to_binary, Addr, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Env,
-    MessageInfo, Response, StdError, StdResult, Storage, SubMsg, Uint128, WasmMsg,
+    MessageInfo, Response, StdError, StdResult, Storage, Uint128, WasmMsg,
 };
 use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg, Cw20ReceiveMsg};
 use cw_utils::must_pay;
@@ -241,7 +241,7 @@ fn claim(
         let transfer_msg = vesting_token
             .with_balance(claim_amount)
             .into_msg(recipient.unwrap_or_else(|| info.sender.to_string()))?;
-        response = response.add_submessage(SubMsg::new(transfer_msg));
+        response = response.add_message(transfer_msg);
 
         sender_vesting_info.released_amount = sender_vesting_info
             .released_amount

--- a/packages/vesting-base/src/ext_managed.rs
+++ b/packages/vesting-base/src/ext_managed.rs
@@ -3,9 +3,7 @@ use crate::handlers::get_vesting_token;
 use crate::msg::{ExecuteMsgManaged, QueryMsgManaged};
 use crate::state::{vesting_info, vesting_state, CONFIG};
 use astroport::asset::AssetInfoExt;
-use cosmwasm_std::{
-    attr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, SubMsg, Uint128,
-};
+use cosmwasm_std::{attr, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128};
 
 /// Contains the managed extension check and routing of the message.
 pub(crate) fn handle_execute_managed_msg(
@@ -86,7 +84,7 @@ fn remove_vesting_accounts(
             let transfer_msg = vesting_token
                 .with_balance(amount_to_claw_back)
                 .into_msg(&deps.querier, clawback_address.clone())?;
-            response = response.add_submessage(SubMsg::new(transfer_msg));
+            response = response.add_message(transfer_msg);
 
             vesting_state(config.extensions.historical).update::<_, ContractError>(
                 deps.storage,

--- a/packages/vesting-base/src/handlers.rs
+++ b/packages/vesting-base/src/handlers.rs
@@ -13,7 +13,7 @@ use astroport::asset::{addr_opt_validate, token_asset_info, AssetInfo, AssetInfo
 use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner};
 use cosmwasm_std::{
     attr, from_binary, to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Response,
-    StdError, StdResult, Storage, SubMsg, Uint128,
+    StdError, StdResult, Storage, Uint128,
 };
 use cw20::Cw20ReceiveMsg;
 use cw_utils::must_pay;
@@ -220,7 +220,7 @@ fn claim(
             &deps.querier,
             recipient.unwrap_or_else(|| info.sender.to_string()),
         )?;
-        response = response.add_submessage(SubMsg::new(transfer_msg));
+        response = response.add_message(transfer_msg);
 
         sender_vesting_info.released_amount = sender_vesting_info
             .released_amount


### PR DESCRIPTION
**task:** https://hadronlabs.atlassian.net/browse/NTRN-127

**this PR:**
- adds missing `set_contract_version` for the lockdrop, vesting investors and vesting lp contracts;
- fixes a typo in lockdrop contract;
- replaces superfluous submsgs with simple msgs for vesting base contracts;
- removes redundant `MigrationState::Started` for lockdrop;
- removes list of exec and query msgs from execute and query entry points description.