### PR TITLE
Fix: update pool on deposit

### DIFF
--- a/contracts/lockdrop-pcl/src/contract.rs
+++ b/contracts/lockdrop-pcl/src/contract.rs
@@ -5,25 +5,25 @@ use std::str::FromStr;
 use astroport::asset::{Asset, AssetInfo};
 use astroport::common::{claim_ownership, drop_ownership_proposal, propose_new_owner};
 use astroport::cosmwasm_ext::IntegerToDecimal;
-use astroport::DecimalCheckedOps;
 use astroport::incentives::{ExecuteMsg as IncentivesExecuteMsg, QueryMsg as IncentivesQueryMsg};
 use astroport::pair::ExecuteMsg::ProvideLiquidity;
 use astroport::restricted_vector::RestrictedVector;
+use astroport::DecimalCheckedOps;
 use cosmwasm_std::{
-    Addr, attr, BankMsg, Binary, coins, CosmosMsg, Decimal, Decimal256, Deps,
-    DepsMut, Empty, entry_point, Env, MessageInfo, Order, Response, StdError, StdResult, to_json_binary,
+    attr, coins, entry_point, to_json_binary, Addr, BankMsg, Binary, CosmosMsg, Decimal,
+    Decimal256, Deps, DepsMut, Empty, Env, MessageInfo, Order, Response, StdError, StdResult,
     Uint128, Uint256, WasmMsg,
 };
-use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg, MinterResponse};
 use cw2::set_contract_version;
+use cw20::{BalanceResponse, Cw20ExecuteMsg, Cw20QueryMsg, MinterResponse};
 
 use astroport_periphery::lockdrop::{
     LockupInfoV2 as LockdropXYKLockupInfoV2, PoolType as LockdropXYKPoolType,
     UserInfo as LockdropXYKUserInfo,
 };
 use astroport_periphery::lockdrop_pcl::{
-    CallbackMsg, Config, ExecuteMsg, InstantiateMsg, LockupInfo, LockUpInfoResponse,
-    LockUpInfoSummary, MigrateMsg, PoolInfo, PoolType, QueryMsg, State, StateResponse, UpdateConfigMsg,
+    CallbackMsg, Config, ExecuteMsg, InstantiateMsg, LockUpInfoResponse, LockUpInfoSummary,
+    LockupInfo, MigrateMsg, PoolInfo, PoolType, QueryMsg, State, StateResponse, UpdateConfigMsg,
     UserInfo, UserInfoResponse, UserInfoWithListResponse,
 };
 use astroport_periphery::utils::Decimal256CheckedOps;
@@ -427,7 +427,7 @@ pub fn handle_migrate_xyk_liquidity(
                 pool_type: pool_type.into(),
                 prev_reward_balances: prev_pending_rewards_balances,
             }
-                .to_cosmos_msg(&env)?,
+            .to_cosmos_msg(&env)?,
         );
     }
 
@@ -442,7 +442,7 @@ pub fn handle_migrate_xyk_liquidity(
             user_info,
             lockup_info,
         }
-            .to_cosmos_msg(&env)?,
+        .to_cosmos_msg(&env)?,
     );
 
     Ok(Response::default().add_messages(cosmos_msgs))
@@ -557,7 +557,7 @@ pub fn handle_claim_rewards_and_unlock_for_lockup(
                 pool_type,
                 prev_reward_balances: prev_pending_rewards_balances,
             }
-                .to_cosmos_msg(&env)?,
+            .to_cosmos_msg(&env)?,
         );
     }
 
@@ -568,7 +568,7 @@ pub fn handle_claim_rewards_and_unlock_for_lockup(
             duration,
             withdraw_lp_stake,
         }
-            .to_cosmos_msg(&env)?,
+        .to_cosmos_msg(&env)?,
     );
 
     Ok(Response::new().add_messages(cosmos_msgs))
@@ -733,7 +733,7 @@ pub fn callback_withdraw_user_rewards_for_lockup_optional_withdraw(
             .lp_units_locked
             .full_mul(balance)
             .checked_div(Uint256::from(pool_info.amount_in_lockups))?)
-            .try_into()?
+        .try_into()?
     };
 
     let mut pending_reward_assets: Vec<Asset> = vec![];
@@ -1130,7 +1130,7 @@ pub fn query_lockup_info(
                 .lp_units_locked
                 .full_mul(pool_astroport_lp_units)
                 .checked_div(Uint256::from(pool_info.amount_in_lockups))?)
-                .try_into()?
+            .try_into()?
         };
         lockup_astroport_lp_units_opt = Some(lockup_astroport_lp_units);
         astroport_lp_token_opt = astroport_lp_token.clone();
@@ -1221,7 +1221,7 @@ pub fn calculate_astro_incentives_for_lockup(
             Uint256::from(pool_incentives_share).checked_mul(lockup_weighted_balance)?,
             Uint256::from(total_incentives_share).checked_mul(total_weighted_amount)?,
         )
-            .checked_mul_uint256(total_lockdrop_incentives.into())?)
+        .checked_mul_uint256(total_lockdrop_incentives.into())?)
     }
 }
 


### PR DESCRIPTION
The incentives contract claims rewards on LP Deposit: https://github.com/astroport-fi/astroport-core/blob/514d83331da3232111c5c590fd8086ef62025ca9/contracts/tokenomics/incentives/src/execute.rs#L190
Thus we need to update pool info after the deposit otherwise there will be unaccounted rewards on PCL lockdrop during users migration